### PR TITLE
Feature/tao 4793 booklet multiple deliveries

### DIFF
--- a/config/default/DeliveryExecutionPacker.conf.php
+++ b/config/default/DeliveryExecutionPacker.conf.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+return new \oat\taoQtiPrint\model\DeliveryExecutionPacker();

--- a/config/default/DeliveryPacker.conf.php
+++ b/config/default/DeliveryPacker.conf.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+return new \oat\taoQtiPrint\model\DeliveryPacker();

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
 	'requires' => array(
 	    'tao' => '>=9.0.0',
         'taoQtiItem' => '>=8.4.8',
-        'taoQtiTest' => '>=10.11.0'
+        'taoQtiTest' => '>=10.14.0'
     ),
 	// for compatibility
 	'dependencies' => array('tao','taoQtiItem'),

--- a/manifest.php
+++ b/manifest.php
@@ -24,12 +24,12 @@ return array(
 	'label' => 'qti',
 	'description' => 'Provides printable rendering for QTI Items',
     'license' => 'GPL-2.0',
-    'version' => '1.3.1',
+    'version' => '1.4.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
 	    'tao' => '>=9.0.0',
         'taoQtiItem' => '>=8.4.8',
-        'taoQtiTest' => '>=7.0.0'
+        'taoQtiTest' => '>=10.11.0'
     ),
 	// for compatibility
 	'dependencies' => array('tao','taoQtiItem'),

--- a/model/DeliveryExecutionPacker.php
+++ b/model/DeliveryExecutionPacker.php
@@ -86,7 +86,7 @@ class DeliveryExecutionPacker extends DeliveryPacker
      * @param string $uri
      * @return array
      */
-    public function getTestData($uri)
+    public function getTestData($uri, $user = '')
     {
         $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($uri);
         $userIdentifier = $deliveryExecution->getUserIdentifier();

--- a/model/DeliveryExecutionPacker.php
+++ b/model/DeliveryExecutionPacker.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+
+namespace oat\taoQtiPrint\model;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\taoDelivery\model\execution\ServiceProxy;
+use oat\taoItems\model\pack\encoders\Base64fileEncoder;
+use oat\taoItems\model\pack\ExceptionMissingAsset;
+use oat\taoOutcomeUi\helper\ResponseVariableFormatter;
+use oat\taoOutcomeUi\model\ResultsService;
+use oat\taoQtiItem\model\QtiJsonItemCompiler;
+use oat\taoQtiTest\models\runner\config\QtiRunnerConfig;
+use oat\taoQtiTest\models\runner\rubric\QtiRunnerRubric;
+use oat\taoQtiTest\models\TestSessionService;
+use oat\taoResultServer\models\classes\ResultServerService;
+
+/**
+ * Class DeliveryExecutionPacker
+ * @package oat\taoQtiPrint\model
+ */
+class DeliveryExecutionPacker extends ConfigurableService
+{
+    const SERVICE_ID = 'taoQtiPrint/DeliveryExecutionPacker';
+    
+    /**
+     * Extracts the result variables related to a Delivery Execution
+     * @param string $uri
+     * @return array
+     */
+    public function getResultVariables($uri)
+    {
+        $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($uri);
+        $resultServerService = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID);
+        $resultStorage = $resultServerService->getResultStorage($deliveryExecution->getDelivery());
+        $resultsService = ResultsService::singleton();
+        $resultsService->setImplementation($resultStorage);
+
+        $displayedVariables = $resultsService->getStructuredVariables($uri, 'lastSubmitted', [\taoResultServer_models_classes_ResponseVariable::class]);
+        $responses = ResponseVariableFormatter::formatStructuredVariablesToItemState($displayedVariables);
+        $excludedVariables = array_flip(['numAttempts', 'duration']);
+
+        $resultVariables = [];
+        foreach ($displayedVariables as &$item) {
+            if (!isset($item['uri'])) {
+                continue;
+            }
+            $itemUri = $item['uri'];
+            if (isset($responses[$itemUri])) {
+                $resultVariables[$itemUri] = array_diff_key($responses[$itemUri], $excludedVariables);
+                if (!count($resultVariables[$itemUri])) {
+                    $resultVariables[$itemUri] = null;
+                }
+            } else {
+                $resultVariables[$itemUri] = null;
+            }
+        }
+
+        return $resultVariables;
+    }
+
+    /**
+     * Extracts the test data related to a Delivery Execution
+     * @param string $uri
+     * @return array
+     */
+    public function getTestData($uri)
+    {
+        $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($uri);
+        $userIdentifier = $deliveryExecution->getUserIdentifier();
+        $deliveryUser = new \core_kernel_users_GenerisUser(new \core_kernel_classes_Resource($userIdentifier));
+        $lang = $deliveryUser->getPropertyValues(PROPERTY_USER_DEFLG);
+        $userDataLang = empty($lang) ? DEFAULT_LANG : (string)current($lang);
+
+        $testSessionService = $this->getServiceLocator()->get(TestSessionService::SERVICE_ID);
+        /* @var \qtism\runtime\tests\AssessmentTestSession $testSession */
+        $testSession = $testSessionService->getTestSession($deliveryExecution);
+        $inputParameters = $testSessionService->getRuntimeInputParameters($deliveryExecution);
+        $fileStorage = \tao_models_classes_service_FileStorage::singleton();
+        $directoryIds = explode('|', $inputParameters['QtiTestCompilation']);
+        $compilationDirs = array(
+            'private' => $fileStorage->getDirectoryById($directoryIds[0]),
+            'public' => $fileStorage->getDirectoryById($directoryIds[1])
+        );
+        $assessmentTest = $testSession->getAssessmentTest();
+        $route = $testSession->getRoute();
+        $routeItems = $route->getAllRouteItems();
+        $lastPart = null;
+        $lastSection = null;
+        $testData = [
+            'type' => 'qtiprint',
+            'data' => [
+                'id' => $assessmentTest->getIdentifier(),
+                'uri' => $uri,
+                'title' => $assessmentTest->getTitle(),
+                'testParts' => [],
+            ],
+            'items' => [],
+        ];
+
+        $rubricBlockHelper = $this->getServiceLocator()->get(QtiRunnerRubric::SERVICE_ID);
+        $config = $this->getServiceLocator()->get(QtiRunnerConfig::SERVICE_ID);
+        $reviewConfig = $config->getConfigValue('review');
+        $displaySubsectionTitle = isset($reviewConfig['displaySubsectionTitle']) ? (bool)$reviewConfig['displaySubsectionTitle'] : true;
+
+        foreach ($routeItems as $routeItem) {
+            $itemRef = $routeItem->getAssessmentItemRef();
+            $testPart = $routeItem->getTestPart();
+            $partId = $testPart->getIdentifier();
+
+            if ($displaySubsectionTitle) {
+                $section = $routeItem->getAssessmentSection();
+            } else {
+                $sections = $routeItem->getAssessmentSections()->getArrayCopy();
+                $section = $sections[0];
+            }
+            $sectionId = $section->getIdentifier();
+            $itemId = $itemRef->getIdentifier();
+            $itemUri = strstr($itemRef->getHref(), '|', true);
+
+            if ($lastPart != $partId) {
+                $lastPart = $partId;
+            }
+            if ($lastSection != $sectionId) {
+                $lastSection = $sectionId;
+            }
+
+            if (!isset($testData['data']['testParts'][$partId])) {
+                $testData['data']['testParts'][$partId] = [
+                    'id' => $partId,
+                    'sections' => [],
+                ];
+            }
+            if (!isset($testData['data']['testParts'][$partId]['sections'][$sectionId])) {
+                $testData['data']['testParts'][$partId]['sections'][$sectionId] = [
+                    'id' => $sectionId,
+                    'title' => $section->getTitle(),
+                    'rubricBlock' => $rubricBlockHelper->getRubricBlock($routeItem, $testSession, $compilationDirs),
+                    'items' => [],
+                ];
+            }
+
+            $testData['data']['testParts'][$partId]['sections'][$sectionId]['items'][] = [
+                'id' => $itemId,
+                'href' => $itemUri,
+            ];
+
+            $testData['items'][$itemUri] = $this->getItemData($itemRef->getHref(), $userDataLang);
+        }
+
+        return $testData;
+    }
+
+    /**
+     * Gets the definition of an item
+     * @param string $itemRef
+     * @param string $userDataLang
+     * @return array
+     * @throws \common_Exception
+     * @throws \common_exception_InconsistentData
+     * @throws \tao_models_classes_FileNotFoundException
+     */
+    protected function getItemData($itemRef, $userDataLang)
+    {
+        $directoryIds = explode('|', $itemRef);
+        if (count($directoryIds) < 3) {
+            throw new \common_exception_InconsistentData('The itemRef is not formatted correctly');
+        }
+
+        $itemUri = $directoryIds[0];
+        $publicDirectory = \tao_models_classes_service_FileStorage::singleton()->getDirectoryById($directoryIds[1]);
+        $privateDirectory = \tao_models_classes_service_FileStorage::singleton()->getDirectoryById($directoryIds[2]);
+
+        if ($privateDirectory->has($userDataLang)) {
+            $lang = $userDataLang;
+        } elseif ($privateDirectory->has(DEFAULT_LANG)) {
+            \common_Logger::i(
+                $userDataLang . ' is not part of compilation directory for item : ' . $itemUri . ' use ' . DEFAULT_LANG
+            );
+            $lang = DEFAULT_LANG;
+        } else {
+            throw new \common_Exception(
+                'item : ' . $itemUri . 'is neither compiled in ' . $userDataLang . ' nor in ' . DEFAULT_LANG
+            );
+        }
+
+        $fileName = QtiJsonItemCompiler::ITEM_FILE_NAME;
+        try {
+            return $this->resolveAssets(
+                json_decode($privateDirectory->read($lang . DIRECTORY_SEPARATOR . $fileName), true),
+                $publicDirectory,
+                $lang
+            );
+        } catch (\FileNotFoundException $e) {
+            throw new \tao_models_classes_FileNotFoundException(
+                $fileName . ' for item reference ' . $itemRef
+            );
+        }
+    }
+
+    /**
+     * @param array $itemData
+     * @param \tao_models_classes_service_StorageDirectory $publicDirectory
+     * @param string $lang
+     * @return array
+     */
+    protected function resolveAssets($itemData, $publicDirectory, $lang)
+    {
+        $itemData['baseUrl'] = $publicDirectory->getPublicAccessUrl() . $lang . '/';
+        $encoder = new Base64fileEncoder($publicDirectory);
+
+        $allowedTypes = ['img', 'css'];
+
+        if (isset($itemData['assets'])) {
+            foreach ($itemData['assets'] as $type => &$assets) {
+                if (in_array($type, $allowedTypes)) {
+                    foreach ($assets as $uri => $asset) {
+                        try {
+                            $assets[$uri] = $encoder->encode($lang . '/' . $asset);
+                        } catch (ExceptionMissingAsset $e) {
+                        }
+                    }
+                }
+            }
+        }
+
+        return $itemData;
+    }
+    
+}

--- a/model/DeliveryPacker.php
+++ b/model/DeliveryPacker.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ */
+
+namespace oat\taoQtiPrint\model;
+
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoDelivery\model\AssignmentService;
+use oat\taoItems\model\pack\encoders\Base64fileEncoder;
+use oat\taoItems\model\pack\ExceptionMissingAsset;
+use oat\taoQtiItem\model\QtiJsonItemCompiler;
+use oat\taoQtiTest\models\runner\config\QtiRunnerConfig;
+use qtism\data\AssessmentItemRef;
+use qtism\data\AssessmentSection;
+use qtism\data\storage\php\PhpDocument;
+
+/**
+ * Class DeliveryPacker
+ *
+ * Extracts the test definition data from a Delivery.
+ * Add the definition of items and theirs related assets, base64 encoded.
+ *
+ * @package oat\taoQtiPrint\model
+ */
+class DeliveryPacker extends ConfigurableService
+{
+    use OntologyAwareTrait;
+
+    const SERVICE_ID = 'taoQtiPrint/DeliveryPacker';
+
+    /**
+     * Extracts the test data related to a Delivery
+     * @param string $uri
+     * @param string $user
+     * @return array
+     */
+    public function getTestData($uri, $user)
+    {
+        $runtime = $this->getServiceLocator()->get(AssignmentService::SERVICE_ID)->getRuntime($uri);
+        $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());
+        $fileStorage = \tao_models_classes_service_FileStorage::singleton();
+        $directoryIds = explode('|', $inputParameters['QtiTestCompilation']);
+        $compilationDirs = array(
+            'private' => $fileStorage->getDirectoryById($directoryIds[0]),
+            'public' => $fileStorage->getDirectoryById($directoryIds[1])
+        );
+
+        $deliveryUser = new \core_kernel_users_GenerisUser(new \core_kernel_classes_Resource($user));
+        $lang = $deliveryUser->getPropertyValues(PROPERTY_USER_DEFLG);
+        $userDataLang = empty($lang) ? DEFAULT_LANG : (string)current($lang);
+
+        $config = $this->getServiceLocator()->get(QtiRunnerConfig::SERVICE_ID);
+        $reviewConfig = $config->getConfigValue('review');
+        $displaySubsectionTitle = isset($reviewConfig['displaySubsectionTitle']) ? (bool)$reviewConfig['displaySubsectionTitle'] : true;
+
+        $testPhp = $compilationDirs['private']->read(TAOQTITEST_COMPILED_FILENAME);
+        $phpDoc = new PhpDocument();
+        $phpDoc->loadFromString($testPhp);
+
+        $testDefinition = $phpDoc->getDocumentComponent();
+
+        $lastPart = null;
+        $lastSection = null;
+        $testData = [
+            'type' => 'qtiprint',
+            'data' => [
+                'id' => $testDefinition->getIdentifier(),
+                'uri' => $uri,
+                'title' => $testDefinition->getTitle(),
+                'testParts' => [],
+            ],
+            'items' => [],
+        ];
+
+        foreach ($testDefinition->getTestParts() as $testPart) {
+            $assessmentSectionStack = array();
+
+            foreach ($testPart->getAssessmentSections() as $assessmentSection) {
+                $trail = array();
+                $mark = array();
+
+                array_push($trail, $assessmentSection);
+
+                while (count($trail) > 0) {
+
+                    $current = array_pop($trail);
+
+                    if (!in_array($current, $mark, true) && $current instanceof AssessmentSection) {
+                        // 1st pass on assessmentSection.
+                        $currentAssessmentSection = $current;
+                        array_push($assessmentSectionStack, $currentAssessmentSection);
+
+                        array_push($mark, $current);
+                        array_push($trail, $current);
+
+                        // Ask for next level traversal.
+                        foreach (array_reverse($current->getSectionParts()->getArrayCopy()) as $sectionPart) {
+                            array_push($trail, $sectionPart);
+                        }
+                    } elseif (in_array($current, $mark, true)) {
+                        array_pop($assessmentSectionStack);
+
+                    } elseif ($current instanceof AssessmentItemRef) {
+                        // leaf node.
+                        // AssessmentSectionHierarchy of AssessmentItemRef is in $assessmentSectionStack
+                        // Test Part of AssessmentItemRef is in $testPart
+
+                        $partId = $testPart->getIdentifier();
+
+                        $sections = [];
+                        foreach ($assessmentSectionStack as $assessmentSectionAncestor) {
+                            array_push($sections, $assessmentSectionAncestor);
+                        }
+                        if ($displaySubsectionTitle) {
+                            $section = array_pop($sections);
+                        } else {
+                            $section = array_shift($sections);
+                        }
+                        $sectionId = $section->getIdentifier();
+                        $itemId = $current->getIdentifier();
+                        $itemUri = strstr($current->getHref(), '|', true);
+
+                        if ($lastPart != $partId) {
+                            $lastPart = $partId;
+                        }
+                        if ($lastSection != $sectionId) {
+                            $lastSection = $sectionId;
+                        }
+
+                        if (!isset($testData['data']['testParts'][$partId])) {
+                            $testData['data']['testParts'][$partId] = [
+                                'id' => $partId,
+                                'sections' => [],
+                            ];
+                        }
+                        if (!isset($testData['data']['testParts'][$partId]['sections'][$sectionId])) {
+                            $testData['data']['testParts'][$partId]['sections'][$sectionId] = [
+                                'id' => $sectionId,
+                                'title' => $section->getTitle(),
+                                'rubricBlock' => '', // TODO: get the rubric block from the delivery
+                                'items' => [],
+                            ];
+                        }
+
+                        $testData['data']['testParts'][$partId]['sections'][$sectionId]['items'][] = [
+                            'id' => $itemId,
+                            'href' => $itemUri,
+                        ];
+
+                        $testData['items'][$itemUri] = $this->getItemData($current->getHref(), $userDataLang);
+                    }
+                }
+            }
+        }
+
+        return $testData;
+    }
+
+    /**
+     * Gets the definition of an item
+     * @param string $itemRef
+     * @param string $userDataLang
+     * @return array
+     * @throws \common_Exception
+     * @throws \common_exception_InconsistentData
+     * @throws \tao_models_classes_FileNotFoundException
+     */
+    protected function getItemData($itemRef, $userDataLang)
+    {
+        $directoryIds = explode('|', $itemRef);
+        if (count($directoryIds) < 3) {
+            throw new \common_exception_InconsistentData('The itemRef is not formatted correctly');
+        }
+
+        $itemUri = $directoryIds[0];
+        $publicDirectory = \tao_models_classes_service_FileStorage::singleton()->getDirectoryById($directoryIds[1]);
+        $privateDirectory = \tao_models_classes_service_FileStorage::singleton()->getDirectoryById($directoryIds[2]);
+
+        if ($privateDirectory->has($userDataLang)) {
+            $lang = $userDataLang;
+        } elseif ($privateDirectory->has(DEFAULT_LANG)) {
+            \common_Logger::i(
+                $userDataLang . ' is not part of compilation directory for item : ' . $itemUri . ' use ' . DEFAULT_LANG
+            );
+            $lang = DEFAULT_LANG;
+        } else {
+            throw new \common_Exception(
+                'item : ' . $itemUri . 'is neither compiled in ' . $userDataLang . ' nor in ' . DEFAULT_LANG
+            );
+        }
+
+        $fileName = QtiJsonItemCompiler::ITEM_FILE_NAME;
+        try {
+            return $this->resolveAssets(
+                json_decode($privateDirectory->read($lang . DIRECTORY_SEPARATOR . $fileName), true),
+                $publicDirectory,
+                $lang
+            );
+        } catch (\FileNotFoundException $e) {
+            throw new \tao_models_classes_FileNotFoundException(
+                $fileName . ' for item reference ' . $itemRef
+            );
+        }
+    }
+
+    /**
+     * @param array $itemData
+     * @param \tao_models_classes_service_StorageDirectory $publicDirectory
+     * @param string $lang
+     * @return array
+     */
+    protected function resolveAssets($itemData, $publicDirectory, $lang)
+    {
+        $itemData['baseUrl'] = $publicDirectory->getPublicAccessUrl() . $lang . '/';
+        $encoder = new Base64fileEncoder($publicDirectory);
+
+        $allowedTypes = ['img', 'css'];
+
+        if (isset($itemData['assets'])) {
+            foreach ($itemData['assets'] as $type => &$assets) {
+                if (in_array($type, $allowedTypes)) {
+                    foreach ($assets as $uri => $asset) {
+                        try {
+                            $assets[$uri] = $encoder->encode($lang . '/' . $asset);
+                        } catch (ExceptionMissingAsset $e) {
+                        }
+                    }
+                }
+            }
+        }
+
+        return $itemData;
+    }
+
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -20,6 +20,7 @@
 namespace oat\taoQtiPrint\scripts\update;
 
 use oat\taoQtiPrint\model\DeliveryExecutionPacker;
+use oat\taoQtiPrint\model\DeliveryPacker;
 
 /**
  * Class Updater
@@ -37,6 +38,7 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('0.1.0', '1.3.1');
 
         if ($this->isVersion('1.3.1')) {
+            $this->getServiceManager()->register(DeliveryPacker::SERVICE_ID, new DeliveryPacker());
             $this->getServiceManager()->register(DeliveryExecutionPacker::SERVICE_ID, new DeliveryExecutionPacker());
             $this->setVersion('1.4.0');
         }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -15,10 +15,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
- *
- *
  */
+
 namespace oat\taoQtiPrint\scripts\update;
+
+use oat\taoQtiPrint\model\DeliveryExecutionPacker;
 
 /**
  * Class Updater
@@ -34,6 +35,11 @@ class Updater extends \common_ext_ExtensionUpdater
     public function update($initialVersion) {
 
         $this->skip('0.1.0', '1.3.1');
+
+        if ($this->isVersion('1.3.1')) {
+            $this->getServiceManager()->register(DeliveryExecutionPacker::SERVICE_ID, new DeliveryExecutionPacker());
+            $this->setVersion('1.4.0');
+        }
 
     }
 }

--- a/views/js/qtiPrintRenderer/renderers/RubricBlock.js
+++ b/views/js/qtiPrintRenderer/renderers/RubricBlock.js
@@ -34,6 +34,12 @@ function(tpl, getContainer){
     return {
         qtiClass:     'rubricBlock',
         getContainer: getContainer,
-        template:     tpl
+        template:     tpl,
+        getData : function getData(rubric, data){
+            if(rubric.isEmpty()){
+                data.empty = true;
+            }
+            return data;
+        }
     };
 });

--- a/views/js/qtiPrintRenderer/tpl/rubricBlock.tpl
+++ b/views/js/qtiPrintRenderer/tpl/rubricBlock.tpl
@@ -1,5 +1,7 @@
+{{#unless empty}}
 <div class="grid-row qti-rubricBlock" data-use="{{attributes.use}}" data-serial="{{serial}}" data-qti-class="rubricBlock">
     <div class="col-12">
         <div class="qti-rubricBlock-body">{{{body}}}</div>
     </div>
 </div>
+{{/unless}}

--- a/views/js/runner/testRenderers.js
+++ b/views/js/runner/testRenderers.js
@@ -61,7 +61,8 @@ define([
                 subtitle: coverPageOptions['description'] && options.description,
                 qrcode: coverPageOptions['qr_code'],
                 logo: coverPageOptions['logo'] && options.logo,
-                date: coverPageOptions['date'] && options.date
+                date: coverPageOptions['date'] && options.date,
+                uniqid: coverPageOptions['unique_id'] && options.unique_id
             })).appendTo($container);
 
             if (coverPageOptions['qr_code']) {

--- a/views/js/runner/tpl/pageTest.tpl
+++ b/views/js/runner/tpl/pageTest.tpl
@@ -1,3 +1,6 @@
+{{#if uniqid}}
+<h3>{{uniqid}}</h3>
+{{/if}}
 {{#if logo}}
     <div class="logo">
         <img src="{{logo}}" alt="{{__ "Logo"}}" />


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4793

Requires: https://github.com/oat-sa/extension-tao-testqti/pull/915

- Includes packers dedicated to Delivery and DeliveryExecution to extract the test definition.
- Can accept a list of tests to print instead only one.
- Add an option to print a unique identifier on the cover page (The header and footer options are handled from the companion extension taoBooklet).