### PR TITLE
Fix/tao 4144 cover page qr code

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'qti',
 	'description' => 'Provides printable rendering for QTI Items',
     'license' => 'GPL-2.0',
-    'version' => '1.4.1',
+    'version' => '1.5.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
 	    'tao' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -42,7 +42,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(DeliveryExecutionPacker::SERVICE_ID, new DeliveryExecutionPacker());
             $this->setVersion('1.4.0');
         }
-        $this->skip('1.4.0', '1.4.1');
+        $this->skip('1.4.0', '1.5.0');
 
     }
 }

--- a/views/js/runner/testRenderers.js
+++ b/views/js/runner/testRenderers.js
@@ -67,7 +67,7 @@ define([
 
             if (coverPageOptions['qr_code']) {
                 new QRCode($('.qr-code', $container).get(0), {
-                    text: coverPageOptions['qr_code_data'] || urlHelper.route('render', 'PrintTest', 'taoBooklet', {uri: test.uri}),
+                    text: coverPageOptions['qr_code_data'] || urlHelper.route('render', 'PrintTest', 'taoBooklet', {uri: options.uri}),
                     width: 192,
                     height: 192,
                     colorDark: "#000000",

--- a/views/js/runner/testRenderers.js
+++ b/views/js/runner/testRenderers.js
@@ -67,7 +67,7 @@ define([
 
             if (coverPageOptions['qr_code']) {
                 new QRCode($('.qr-code', $container).get(0), {
-                    text: urlHelper.route('render', 'PrintTest', 'taoBooklet', {uri: test.uri}),
+                    text: coverPageOptions['qr_code_data'] || urlHelper.route('render', 'PrintTest', 'taoBooklet', {uri: test.uri}),
                     width: 192,
                     height: 192,
                     colorDark: "#000000",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4144

The URL encoded in the QR code is now relying on the URI provided in the config instead on the test URI. It could also be overwritten bu using the config entry `qr_code_data`.