### PR TITLE
feature/TAO-7629 qunit 2 migration

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,10 +24,10 @@ return array(
 	'label' => 'qti',
 	'description' => 'Provides printable rendering for QTI Items',
     'license' => 'GPL-2.0',
-    'version' => '1.7.6',
+    'version' => '1.8.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
-	    'tao' => '>=9.0.0',
+	    'tao' => '>=30.0.0',
         'taoQtiItem' => '>=8.4.8',
         'taoQtiTest' => '>=10.14.0'
     ),

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'qti',
 	'description' => 'Provides printable rendering for QTI Items',
     'license' => 'GPL-2.0',
-    'version' => '1.7.5',
+    'version' => '1.7.6',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
 	    'tao' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -42,7 +42,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(DeliveryExecutionPacker::SERVICE_ID, new DeliveryExecutionPacker());
             $this->setVersion('1.4.0');
         }
-        $this->skip('1.4.0', '1.7.5');
+        $this->skip('1.4.0', '1.7.6');
 
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -42,7 +42,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(DeliveryExecutionPacker::SERVICE_ID, new DeliveryExecutionPacker());
             $this->setVersion('1.4.0');
         }
-        $this->skip('1.4.0', '1.7.6');
+        $this->skip('1.4.0', '1.8.0');
 
     }
 }

--- a/views/js/test/runner/itemRunner/test.html
+++ b/views/js/test/runner/itemRunner/test.html
@@ -7,8 +7,8 @@
 
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="itemRunner.js"></script>
 
         <script  type="text/javascript">

--- a/views/js/test/runner/itemRunner/test.js
+++ b/views/js/test/runner/itemRunner/test.js
@@ -1,18 +1,18 @@
-define( [  'taoQtiPrint/runner/itemRunner' ], function(  itemRunner ) {
+define(['taoQtiPrint/runner/itemRunner'], function(itemRunner) {
 
-    QUnit.module( 'Runner API' );
+    QUnit.module('Runner API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.ok( typeof itemRunner !== 'undefined', 'The module exports something' );
-        assert.ok( typeof itemRunner === 'function', 'The module exports a function' );
-    } );
+    QUnit.test('module', function(assert) {
+        assert.ok(typeof itemRunner !== 'undefined', 'The module exports something');
+        assert.ok(typeof itemRunner === 'function', 'The module exports a function');
+    });
 
-    QUnit.module( 'QTI Provider' );
+    QUnit.module('QTI Provider');
 
-    QUnit.test( 'provider registered', function( assert ) {
-        assert.ok( typeof itemRunner.providers !== 'undefined', 'The runner has providers' );
-        assert.ok( typeof itemRunner.providers.qtiprint !== 'undefined', 'The runner has a QTI provider' );
-    } );
+    QUnit.test('provider registered', function(assert) {
+        assert.ok(typeof itemRunner.providers !== 'undefined', 'The runner has providers');
+        assert.ok(typeof itemRunner.providers.qtiprint !== 'undefined', 'The runner has a QTI provider');
+    });
 
-} );
+});
 

--- a/views/js/test/runner/itemRunner/test.js
+++ b/views/js/test/runner/itemRunner/test.js
@@ -1,21 +1,18 @@
-define([
-    'taoQtiPrint/runner/itemRunner'
-], function(itemRunner){
+define( [  'taoQtiPrint/runner/itemRunner' ], function(  itemRunner ) {
 
+    QUnit.module( 'Runner API' );
 
-    QUnit.module('Runner API');
+    QUnit.test( 'module', function( assert ) {
+        assert.ok( typeof itemRunner !== 'undefined', 'The module exports something' );
+        assert.ok( typeof itemRunner === 'function', 'The module exports a function' );
+    } );
 
-    QUnit.test('module', function(assert){
-        assert.ok(typeof itemRunner !== 'undefined', "The module exports something");
-        assert.ok(typeof itemRunner === 'function', "The module exports a function");
-    });
+    QUnit.module( 'QTI Provider' );
 
-    QUnit.module('QTI Provider');
+    QUnit.test( 'provider registered', function( assert ) {
+        assert.ok( typeof itemRunner.providers !== 'undefined', 'The runner has providers' );
+        assert.ok( typeof itemRunner.providers.qtiprint !== 'undefined', 'The runner has a QTI provider' );
+    } );
 
-    QUnit.test('provider registered', function(assert){
-        assert.ok(typeof itemRunner.providers !== 'undefined', "The runner has providers");
-        assert.ok(typeof itemRunner.providers.qtiprint !== 'undefined', "The runner has a QTI provider");
-    });
-
-});
+} );
 

--- a/views/js/test/runner/provider/test.html
+++ b/views/js/test/runner/provider/test.html
@@ -7,14 +7,15 @@
 
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="provider/qtiprint"></script>
 
         <script  type="text/javascript">
 
             //don't start the test now
             QUnit.config.autostart = false;
+            QUnit.config.notrycatch =true;
 
             //load the config
             require(['/tao/ClientConfig/config'], function(){

--- a/views/js/test/runner/provider/test.js
+++ b/views/js/test/runner/provider/test.js
@@ -1,113 +1,113 @@
-define( [
-    
+define([
+
     'jquery',
     'lodash',
     'taoItems/runner/api/itemRunner',
     'taoQtiPrint/runner/provider/qtiprint',
     'json!taoQtiPrint/test/samples/space-shuttle.json'
-], function(  $, _, itemRunner, qtiRuntimeProvider, itemData ) {
+], function($, _, itemRunner, qtiRuntimeProvider, itemData) {
 
     var containerId = 'item-container';
 
-    QUnit.module( 'Provider API' );
+    QUnit.module('Provider API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.ok( typeof qtiRuntimeProvider !== 'undefined', 'The module exports something' );
-        assert.ok( typeof qtiRuntimeProvider === 'object', 'The module exports an object' );
-        assert.ok( typeof qtiRuntimeProvider.init === 'function' || typeof qtiRuntimeProvider.render === 'function', 'The provider expose an init or a render method' );
-    } );
+    QUnit.test('module', function(assert) {
+        assert.ok(typeof qtiRuntimeProvider !== 'undefined', 'The module exports something');
+        assert.ok(typeof qtiRuntimeProvider === 'object', 'The module exports an object');
+        assert.ok(typeof qtiRuntimeProvider.init === 'function' || typeof qtiRuntimeProvider.render === 'function', 'The provider expose an init or a render method');
+    });
 
-    QUnit.module( 'Register the provider', {
-        afterEach: function( assert ) {
+    QUnit.module('Register the provider', {
+        afterEach: function(assert) {
 
             //Reset the provider
             itemRunner.providers = undefined;
         }
-    } );
+    });
 
-    QUnit.test( 'register the qti provider', function( assert ) {
-        assert.expect( 4 );
+    QUnit.test('register the qti provider', function(assert) {
+        assert.expect(4);
 
-        assert.ok( typeof itemRunner.providers === 'undefined', 'the runner has no providers' );
+        assert.ok(typeof itemRunner.providers === 'undefined', 'the runner has no providers');
 
-        itemRunner.register( 'qtiprint', qtiRuntimeProvider );
+        itemRunner.register('qtiprint', qtiRuntimeProvider);
 
-        assert.ok( typeof itemRunner.providers === 'object', 'the runner has now providers' );
-        assert.ok( typeof itemRunner.providers.qtiprint === 'object', 'the runner has now the qtiprint providers' );
-        assert.equal( itemRunner.providers.qtiprint, qtiRuntimeProvider, 'the runner has now the qtiprint providers' );
+        assert.ok(typeof itemRunner.providers === 'object', 'the runner has now providers');
+        assert.ok(typeof itemRunner.providers.qtiprint === 'object', 'the runner has now the qtiprint providers');
+        assert.equal(itemRunner.providers.qtiprint, qtiRuntimeProvider, 'the runner has now the qtiprint providers');
 
-    } );
+    });
 
-    QUnit.module( 'Provider init', {
+    QUnit.module('Provider init', {
         beforeEach: function (){
             itemRunner.providers = undefined;
 
         }
-    } );
+    });
 
-    QUnit.test( 'Item data loading', function( assert ) {
+    QUnit.test('Item data loading', function(assert) {
         var ready = assert.async();
-        assert.expect( 2 );
+        assert.expect(2);
 
-        itemRunner.register( 'qtiprint', qtiRuntimeProvider );
+        itemRunner.register('qtiprint', qtiRuntimeProvider);
 
-        itemRunner( 'qtiprint', itemData, {
-            renderer:'results'
-        } )
-          .on( 'init', function() {
+        itemRunner('qtiprint', itemData, {
+            renderer: 'results'
+        })
+          .on('init', function() {
 
-            assert.ok( typeof this._item === 'object', 'The item data is loaded and mapped to an object' );
-            assert.ok( typeof this._item.bdy === 'object', 'The item contains a body object' );
+              assert.ok(typeof this._item === 'object', 'The item data is loaded and mapped to an object');
+              assert.ok(typeof this._item.bdy === 'object', 'The item contains a body object');
 
-            ready();
-          } ).init();
-    } );
+              ready();
+          }).init();
+    });
 
-    QUnit.test( 'Loading wrong data', function( assert ) {
+    QUnit.test('Loading wrong data', function(assert) {
         var ready = assert.async();
-        assert.expect( 2 );
+        assert.expect(2);
 
-        itemRunner.register( 'qtiprint', qtiRuntimeProvider );
+        itemRunner.register('qtiprint', qtiRuntimeProvider);
 
-        itemRunner( 'qtiprint', { foo: true } )
-          .on( 'error', function( message ) {
+        itemRunner('qtiprint', {foo: true})
+          .on('error', function(message) {
 
-            assert.ok( true, 'The provider triggers an error event' );
-            assert.ok( typeof message === 'string', 'The error is a string' );
+              assert.ok(true, 'The provider triggers an error event');
+              assert.ok(typeof message === 'string', 'The error is a string');
 
-            ready();
-          } ).init();
-    } );
+              ready();
+          }).init();
+    });
 
-    QUnit.module( 'Provider render', {
-        afterEach: function( assert ) {
+    QUnit.module('Provider render', {
+        afterEach: function(assert) {
 
             //Reset the provides
             itemRunner.providers = undefined;
         }
-    } );
+    });
 
-    QUnit.test( 'Item rendering', function( assert ) {
+    QUnit.test('Item rendering', function(assert) {
         var ready = assert.async();
-        assert.expect( 3 );
+        assert.expect(3);
 
-        var $container = $( '#' + containerId );
+        var $container = $('#' + containerId);
 
-        assert.equal( $container.length, 1, 'the item container exists' );
-        assert.equal( $container.children().length, 0, 'the container has no children' );
+        assert.equal($container.length, 1, 'the item container exists');
+        assert.equal($container.children().length, 0, 'the container has no children');
 
-        itemRunner.register( 'qtiprint', qtiRuntimeProvider );
+        itemRunner.register('qtiprint', qtiRuntimeProvider);
 
-        itemRunner( 'qtiprint', itemData )
-            .on( 'render', function() {
+        itemRunner('qtiprint', itemData)
+            .on('render', function() {
 
-                assert.equal( $container.children().length, 1, 'the container has children' );
+                assert.equal($container.children().length, 1, 'the container has children');
 
                 ready();
-            } )
+            })
             .init()
-            .render( $container );
-    } );
+            .render($container);
+    });
 
-} );
+});
 

--- a/views/js/test/runner/provider/test.js
+++ b/views/js/test/runner/provider/test.js
@@ -1,112 +1,113 @@
-define([
+define( [
+    
     'jquery',
     'lodash',
     'taoItems/runner/api/itemRunner',
     'taoQtiPrint/runner/provider/qtiprint',
     'json!taoQtiPrint/test/samples/space-shuttle.json'
-], function($, _, itemRunner, qtiRuntimeProvider, itemData){
+], function(  $, _, itemRunner, qtiRuntimeProvider, itemData ) {
 
     var containerId = 'item-container';
 
+    QUnit.module( 'Provider API' );
 
-    QUnit.module('Provider API');
+    QUnit.test( 'module', function( assert ) {
+        assert.ok( typeof qtiRuntimeProvider !== 'undefined', 'The module exports something' );
+        assert.ok( typeof qtiRuntimeProvider === 'object', 'The module exports an object' );
+        assert.ok( typeof qtiRuntimeProvider.init === 'function' || typeof qtiRuntimeProvider.render === 'function', 'The provider expose an init or a render method' );
+    } );
 
-    QUnit.test('module', function(assert){
-        assert.ok(typeof qtiRuntimeProvider !== 'undefined', "The module exports something");
-        assert.ok(typeof qtiRuntimeProvider === 'object', "The module exports an object");
-        assert.ok(typeof qtiRuntimeProvider.init === 'function' || typeof qtiRuntimeProvider.render === 'function', "The provider expose an init or a render method");
-    });
+    QUnit.module( 'Register the provider', {
+        afterEach: function( assert ) {
 
-
-
-    QUnit.module('Register the provider', {
-        teardown : function(){
-            //reset the provider
+            //Reset the provider
             itemRunner.providers = undefined;
         }
-    });
+    } );
 
-    QUnit.test('register the qti provider', function(assert){
-        QUnit.expect(4);
+    QUnit.test( 'register the qti provider', function( assert ) {
+        assert.expect( 4 );
 
-        assert.ok(typeof itemRunner.providers === 'undefined', 'the runner has no providers');
+        assert.ok( typeof itemRunner.providers === 'undefined', 'the runner has no providers' );
 
-        itemRunner.register('qtiprint', qtiRuntimeProvider);
+        itemRunner.register( 'qtiprint', qtiRuntimeProvider );
 
-        assert.ok(typeof itemRunner.providers === 'object', 'the runner has now providers');
-        assert.ok(typeof itemRunner.providers.qtiprint === 'object', 'the runner has now the qtiprint providers');
-        assert.equal(itemRunner.providers.qtiprint, qtiRuntimeProvider, 'the runner has now the qtiprint providers');
+        assert.ok( typeof itemRunner.providers === 'object', 'the runner has now providers' );
+        assert.ok( typeof itemRunner.providers.qtiprint === 'object', 'the runner has now the qtiprint providers' );
+        assert.equal( itemRunner.providers.qtiprint, qtiRuntimeProvider, 'the runner has now the qtiprint providers' );
 
-    });
+    } );
 
+    QUnit.module( 'Provider init', {
+        beforeEach: function (){
+            itemRunner.providers = undefined;
 
+        }
+    } );
 
-    QUnit.module('Provider init', {
-        teardown : function(){
-            //reset the provides
+    QUnit.test( 'Item data loading', function( assert ) {
+        var ready = assert.async();
+        assert.expect( 2 );
+
+        itemRunner.register( 'qtiprint', qtiRuntimeProvider );
+
+        itemRunner( 'qtiprint', itemData, {
+            renderer:'results'
+        } )
+          .on( 'init', function() {
+
+            assert.ok( typeof this._item === 'object', 'The item data is loaded and mapped to an object' );
+            assert.ok( typeof this._item.bdy === 'object', 'The item contains a body object' );
+
+            ready();
+          } ).init();
+    } );
+
+    QUnit.test( 'Loading wrong data', function( assert ) {
+        var ready = assert.async();
+        assert.expect( 2 );
+
+        itemRunner.register( 'qtiprint', qtiRuntimeProvider );
+
+        itemRunner( 'qtiprint', { foo: true } )
+          .on( 'error', function( message ) {
+
+            assert.ok( true, 'The provider triggers an error event' );
+            assert.ok( typeof message === 'string', 'The error is a string' );
+
+            ready();
+          } ).init();
+    } );
+
+    QUnit.module( 'Provider render', {
+        afterEach: function( assert ) {
+
+            //Reset the provides
             itemRunner.providers = undefined;
         }
-    });
+    } );
 
-    QUnit.asyncTest('Item data loading', function(assert){
-        QUnit.expect(2);
+    QUnit.test( 'Item rendering', function( assert ) {
+        var ready = assert.async();
+        assert.expect( 3 );
 
-        itemRunner.register('qtiprint', qtiRuntimeProvider);
+        var $container = $( '#' + containerId );
 
+        assert.equal( $container.length, 1, 'the item container exists' );
+        assert.equal( $container.children().length, 0, 'the container has no children' );
 
-        itemRunner('qtiprint', itemData)
-          .on('init', function(){
+        itemRunner.register( 'qtiprint', qtiRuntimeProvider );
 
-            assert.ok(typeof this._item === 'object', 'The item data is loaded and mapped to an object');
-            assert.ok(typeof this._item.bdy === 'object', 'The item contains a body object');
+        itemRunner( 'qtiprint', itemData )
+            .on( 'render', function() {
 
-            QUnit.start();
-          }).init();
-    });
+                assert.equal( $container.children().length, 1, 'the container has children' );
 
-    QUnit.asyncTest('Loading wrong data', function(assert){
-        QUnit.expect(2);
-
-        itemRunner.register('qtiprint', qtiRuntimeProvider);
-
-        itemRunner('qtiprint', { foo : true})
-          .on('error', function(message){
-
-            assert.ok(true, 'The provider triggers an error event');
-            assert.ok(typeof message === 'string', 'The error is a string');
-
-            QUnit.start();
-          }).init();
-    });
-
-
-    QUnit.module('Provider render', {
-        teardown : function(){
-            //reset the provides
-            itemRunner.providers = undefined;
-        }
-    });
-
-    QUnit.asyncTest('Item rendering', function(assert){
-        QUnit.expect(3);
-
-        var $container = $('#' + containerId);
-
-        assert.equal($container.length, 1, 'the item container exists');
-        assert.equal($container.children().length, 0, 'the container has no children');
-
-        itemRunner.register('qtiprint', qtiRuntimeProvider);
-
-        itemRunner('qtiprint', itemData)
-            .on('render', function(){
-
-                assert.equal($container.children().length, 1, 'the container has children');
-
-                QUnit.start();
-            })
+                ready();
+            } )
             .init()
-            .render($container);
-    });
+            .render( $container );
+    } );
 
-});
+} );
 

--- a/views/js/test/runner/testRunner/test.html
+++ b/views/js/test/runner/testRunner/test.html
@@ -7,8 +7,8 @@
 
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="testRunner.js"></script>
 
         <script  type="text/javascript">

--- a/views/js/test/runner/testRunner/test.js
+++ b/views/js/test/runner/testRunner/test.js
@@ -1,53 +1,55 @@
-define([
+define( [
+    
     'jquery',
     'taoQtiPrint/runner/testRunner',
     'json!taoQtiPrint/test/samples/test.json'
-], function($, testRunner, testData){
+], function(  $, testRunner, testData ) {
 
     var container = 'container';
 
-    QUnit.module('Runner API');
+    QUnit.module( 'Runner API' );
 
-    QUnit.test('module', 2, function(assert){
-        assert.ok(typeof testRunner !== 'undefined', "The module exports something");
-        assert.ok(typeof testRunner === 'function', "The module exports a function");
-    });
+    QUnit.test( 'module', function( assert ) {
+        assert.ok( typeof testRunner !== 'undefined', 'The module exports something' );
+        assert.ok( typeof testRunner === 'function', 'The module exports a function' );
+    } );
 
-    QUnit.test('data validation', 4, function(assert){
+    QUnit.test( 'data validation', function( assert ) {
 
-        assert.throws(function(){
-            testRunner(null);
-        }, Error, "The test runner should be initialized with data");
+        assert.throws( function() {
+            testRunner( null );
+        }, Error, 'The test runner should be initialized with data' );
 
-        assert.throws(function(){
-            testRunner({});
-        }, Error, "The test runner should be initialized with valid");
+        assert.throws( function() {
+            testRunner( {} );
+        }, Error, 'The test runner should be initialized with valid' );
 
-        assert.throws(function(){
-            testRunner({ data : {} });
-        }, Error, "The test runner should be initialized with items");
+        assert.throws( function() {
+            testRunner( { data: {} } );
+        }, Error, 'The test runner should be initialized with items' );
 
-        assert.ok( typeof testRunner({ data : {}, items : {}}) === 'object', "The test runner creates an object");
-    });
+        assert.ok( typeof testRunner( { data: {}, items: {} } ) === 'object', 'The test runner creates an object' );
+    } );
 
-    QUnit.module('Render');
+    QUnit.module( 'Render' );
 
-    QUnit.asyncTest('renders a test', function(assert){
-        QUnit.expect(2);
+    QUnit.test( 'renders a test', function( assert ) {
+        var ready = assert.async();
+        assert.expect( 2 );
 
-        var $container = $('.' + container);
+        var $container = $( '.' + container );
 
-        assert.equal($container.length, 1, 'The container exists');
+        assert.equal( $container.length, 1, 'The container exists' );
 
-        testRunner(testData)
-            .on('error', function(e){
-                assert.ok(false, 'The test runner has failed :' + e);
-            })
-            .on('ready', function(){
-                assert.equal($container.children().length, 3, 'The container contains now 3 pages');
-                QUnit.start();
-            })
-            .render($container);
-    });
-});
+        testRunner( testData )
+            .on( 'error', function( e ) {
+                assert.ok( false, 'The test runner has failed :' + e );
+            } )
+            .on( 'ready', function() {
+                assert.equal( $container.children().length, 3, 'The container contains now 3 pages' );
+                ready();
+            } )
+            .render( $container );
+    } );
+} );
 

--- a/views/js/test/runner/testRunner/test.js
+++ b/views/js/test/runner/testRunner/test.js
@@ -1,55 +1,55 @@
-define( [
-    
+define([
+
     'jquery',
     'taoQtiPrint/runner/testRunner',
     'json!taoQtiPrint/test/samples/test.json'
-], function(  $, testRunner, testData ) {
+], function($, testRunner, testData) {
 
     var container = 'container';
 
-    QUnit.module( 'Runner API' );
+    QUnit.module('Runner API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.ok( typeof testRunner !== 'undefined', 'The module exports something' );
-        assert.ok( typeof testRunner === 'function', 'The module exports a function' );
-    } );
+    QUnit.test('module', function(assert) {
+        assert.ok(typeof testRunner !== 'undefined', 'The module exports something');
+        assert.ok(typeof testRunner === 'function', 'The module exports a function');
+    });
 
-    QUnit.test( 'data validation', function( assert ) {
+    QUnit.test('data validation', function(assert) {
 
-        assert.throws( function() {
-            testRunner( null );
-        }, Error, 'The test runner should be initialized with data' );
+        assert.throws(function() {
+            testRunner(null);
+        }, Error, 'The test runner should be initialized with data');
 
-        assert.throws( function() {
-            testRunner( {} );
-        }, Error, 'The test runner should be initialized with valid' );
+        assert.throws(function() {
+            testRunner({});
+        }, Error, 'The test runner should be initialized with valid');
 
-        assert.throws( function() {
-            testRunner( { data: {} } );
-        }, Error, 'The test runner should be initialized with items' );
+        assert.throws(function() {
+            testRunner({data: {}});
+        }, Error, 'The test runner should be initialized with items');
 
-        assert.ok( typeof testRunner( { data: {}, items: {} } ) === 'object', 'The test runner creates an object' );
-    } );
+        assert.ok(typeof testRunner({data: {}, items: {}}) === 'object', 'The test runner creates an object');
+    });
 
-    QUnit.module( 'Render' );
+    QUnit.module('Render');
 
-    QUnit.test( 'renders a test', function( assert ) {
+    QUnit.test('renders a test', function(assert) {
         var ready = assert.async();
-        assert.expect( 2 );
+        assert.expect(2);
 
-        var $container = $( '.' + container );
+        var $container = $('.' + container);
 
-        assert.equal( $container.length, 1, 'The container exists' );
+        assert.equal($container.length, 1, 'The container exists');
 
-        testRunner( testData )
-            .on( 'error', function( e ) {
-                assert.ok( false, 'The test runner has failed :' + e );
-            } )
-            .on( 'ready', function() {
-                assert.equal( $container.children().length, 3, 'The container contains now 3 pages' );
+        testRunner(testData)
+            .on('error', function(e) {
+                assert.ok(false, 'The test runner has failed :' + e);
+            })
+            .on('ready', function() {
+                assert.equal($container.children().length, 3, 'The container contains now 3 pages');
                 ready();
-            } )
-            .render( $container );
-    } );
-} );
+            })
+            .render($container);
+    });
+});
 


### PR DESCRIPTION
**task** https://oat-sa.atlassian.net/browse/TAO-7629

 **description**  convert all unit tests for frontend part to latest Qunit 2 version. More details - in task.
 
**related PRs**
https://github.com/oat-sa/extension-tao-xmledit/pull/18
https://github.com/oat-sa/extension-tao-test/pull/273
https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/96
https://github.com/oat-sa/extension-tao-testcenter/pull/118
https://github.com/oat-sa/extension-tao-task-queue/pull/83
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/14
https://github.com/oat-sa/extension-tao-testqti/pull/1446
https://github.com/oat-sa/extension-tao-itemqti/pull/1248
https://github.com/oat-sa/extension-tao-proctoring/pull/673
https://github.com/oat-sa/extension-tao-outcomeui/pull/254
https://github.com/oat-sa/extension-tao-item/pull/355
https://github.com/oat-sa/extension-tao-clientdiag/pull/223
https://github.com/oat-sa/extension-tao-booklet/pull/82
https://github.com/oat-sa/extension-tao-blueprints/pull/20
https://github.com/oat-sa/extension-tao-itemqti-pci/pull/147
https://github.com/oat-sa/extension-pcisample/pull/44