### PR TITLE
feature/BSA-207/add support for custom styles

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'qti',
     'description' => 'Provides printable rendering for QTI Items',
     'license' => 'GPL-2.0',
-    'version' => '1.13.1',
+    'version' => '1.14.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=30.0.0',

--- a/views/js/qtiPrintRenderer/renderers/Item.js
+++ b/views/js/qtiPrintRenderer/renderers/Item.js
@@ -23,7 +23,8 @@
  */
 define([
     'tpl!taoQtiPrint/qtiPrintRenderer/tpl/item',
-    'taoQtiPrint/qtiPrintRenderer/helpers/container'
+    'taoQtiPrint/qtiPrintRenderer/helpers/container',
+    'taoQtiItem/qtiCommonRenderer/helpers/itemStylesheetHandler'
 ], function(tpl, getContainer, itemStylesheetHandler) {
     'use strict';
 
@@ -34,6 +35,14 @@ define([
     return {
         qtiClass:     'assessmentItem',
         template:     tpl,
-        getContainer: getContainer
+        getContainer: getContainer,
+        /**
+         * Rendering initializations for the item
+         * @param {Object} item - the item model
+         */
+        render: function render(item) {
+            //add stylesheets
+            itemStylesheetHandler.attach(item.stylesheets);
+        },
     };
 });

--- a/views/js/qtiPrintRenderer/tpl/stylesheet.tpl
+++ b/views/js/qtiPrintRenderer/tpl/stylesheet.tpl
@@ -1,7 +1,7 @@
-{{!--<link
+<link
     href="{{attributes.href}}"
     type="{{attributes.type}}"
     rel="stylesheet"
     data-serial="{{serial}}"
     {{#if attributes.media}} media="{{attributes.media}}"{{/if}}
-/>--}}
+/>


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/BSA-207

Added support for qtiClass `stylesheet`

How to test:
1. install `wkhtmltopdf` https://hub.taotesting.com/techdocs/tao-booklet/readme-booklet
2. set `define('DEBUG_MODE', false);` in `config/generis.conf.php`
3. in `config/taoBooklet/wkhtmltopdf.conf.php` set binary to wkhtmltopdf path for example `'binary' => '/usr/local/bin/wkhtmltopdf',`
3. compile bundles for taoQtiPrint and taoBooklet
`cd tao/views/build`
`npx grunt taoqtiprintbundle` 
`npx grunt taobookletbundle` 
4. create item **and add css file with custom styles**
5. create test with these item
6. generate booklet from test
7. open booklet in preview and check is css styles applied 
