### PR TITLE
Feature/CON-144/Add new class property to skip validation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,11 +25,11 @@ return [
     'label' => 'qti',
     'description' => 'Provides printable rendering for QTI Items',
     'license' => 'GPL-2.0',
-    'version' => '1.14.1',
+    'version' => '1.15.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=30.0.0',
-        'taoQtiItem' => '>=8.4.8',
+        'taoQtiItem' => '>=25.20.0',
         'taoQtiTest' => '>=10.14.0'
     ],
     // for compatibility

--- a/model/QtiTestPacker.php
+++ b/model/QtiTestPacker.php
@@ -54,6 +54,14 @@ class QtiTestPacker implements Packable, ServiceLocatorAwareInterface
      */
     private static $testType = 'qtiprint';
 
+    /** @var bool */
+    private $skipValidation;
+
+    public function __construct(bool $skipValidation = false)
+    {
+        $this->skipValidation = $skipValidation;
+    }
+
     /**
      * packTest implementation for QTI
      * @see {@link Packable}
@@ -78,7 +86,7 @@ class QtiTestPacker implements Packable, ServiceLocatorAwareInterface
             //pack each test's item
             $items = [];
             foreach ($qtiTestService->getItems($test) as $item) {
-                $itemPacker = new Packer($item, '');
+                $itemPacker = new Packer($item, '', $this->skipValidation);
                 $this->getServiceLocator()->propagate($itemPacker);
                 $items[$item->getUri()] = $itemPacker->pack(['img' => 'base64file']);
             }


### PR DESCRIPTION
**Relates to:** [CON-144](https://oat-sa.atlassian.net/browse/CON-144)

**Changes:**
* Added new class boolean property `$skipValidation`;
* Added new boolean argument `$skipValidation` with default `false` value to `__constructor`.

**Require PR:** [oat-sa/extension-tao-itemqti#1607](https://github.com/oat-sa/extension-tao-itemqti/pull/1607)

**Companion PRs:**
* [oat-sa/extension-tao-item#449](https://github.com/oat-sa/extension-tao-item/pull/449)
* [oat-sa/extension-tao-booklet#114](https://github.com/oat-sa/extension-tao-booklet/pull/114)